### PR TITLE
Fixed Bug where a piece wouldn't be removed if it was captured

### DIFF
--- a/Pieces/Pawn.py
+++ b/Pieces/Pawn.py
@@ -24,5 +24,5 @@ class Pawn(Piece):
             moves.add((tempRow+1,tempCol-1))
         if 0<=tempRow+1<=7 and 0<=tempCol+1<=7 and self.validMove(tempRow,tempCol):
             moves.add((tempRow+1,tempCol+1))
-
+        
         return moves

--- a/Pieces/piece.py
+++ b/Pieces/piece.py
@@ -18,6 +18,9 @@ class Piece():
         self.name=name
         self.row=row
         self.col=col
+        #I add an original col & row for hash and equal purposes
+        self.origRow=row
+        self.origCol=col
         #Add to group and board
         self.board[self.row-1][self.possibleCol[self.col]]=self
         self.group.add(self)
@@ -59,16 +62,23 @@ class Piece():
                 self.col=targetCol
         else:
             print("error FALSE MOVE")
+            print(f' requested {targetRow,targetCol} but available moves are {self.availableMoves()} ALSO {len(self.availableMoves())==0}')
+            print(self.__repr__())
             return False
 
     def removeFromGroup(self):
         #This removes the piece from the current player's set
+        print('test')
+        print(self.group)
+        print(self)
+        print(self in self.group)
+        print('test')
         self.group.remove(self)
     
     def __hash__(self):
-        return hash((self.name,self.row,self.col))
+        return hash((self.name,self.origRow,self.origCol))
     def __eq__(self,other):
-        return type(other) == type(self) and self.name == other.name and self.col==other.col and self.row==other.row
+        return type(other) == type(self) and self.name == other.name and self.origCol==other.origCol and self.origRow==other.origRow
     
     def __repr__(self):
         return f'{self.color[0]}-{self.name}-{self.row}{self.col}' 


### PR DESCRIPTION
To fix this, I added an origRow and origCol to keep track of the original column and row. This way the hash function is constant throughout the game and you are able to delete it from the board. I need to keep the current rows and columns for the arithmetic of the moves of the pieces. 